### PR TITLE
Push to ECR (PS-2190)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,8 @@ variables:
     value: 'keboola-4338'
   - name: imageRepository
     value: 'docker-python-mlflow'
+  - name: registryUrl
+    value: 'keboola.azurecr.io'
 
 pr: none
 trigger:
@@ -40,12 +42,24 @@ jobs:
           latest
           $(imageTag)
 
+    - task: ECRPushImage@1
+      displayName: Push to ECR
+      condition: eq(variables['isTaggedBuild'], 'true')
+      inputs:
+        awsCredentials: 'Production - ECR Distribution - MLFlow'
+        regionName: 'us-east-1'
+        imageSource: 'imagename'
+        repositoryName: 'keboola/$(imageRepository)'
+        sourceImageName: '$(registryUrl)/$(imageRepository)'
+        sourceImageTag: $(imageTag)
+        pushTag: $(imageTag)
+
     - task: Docker@2
+      displayName: 'Push to ACR'
+      condition: eq(variables['isTaggedBuild'], 'true')
       inputs:
         containerRegistry: $(azureContainerRegistry)
         repository: $(imageRepository)
         command: 'push'
         tags: |
           $(imageTag)
-      condition: eq(variables['isTaggedBuild'], 'true')
-      displayName: 'Push latest to ACR'


### PR DESCRIPTION
Abych mohl pustit registraci ml modelu v aws k8s clusteru (https://github.com/keboola/mlflow-provisioning/blob/9e89571f656eb964c88a45039f48a90c9d4bb058/tests/resources/RegisterModel.php#L53), tak je potřeba pushnout tenhle image do ECR. Je to copy&paste podle https://github.com/keboola/mlflow-provisioning-docker-deployment/pull/2/files